### PR TITLE
Add dice modifiers for RNG command

### DIFF
--- a/docs/JSON.md
+++ b/docs/JSON.md
@@ -278,19 +278,20 @@ giv --json now --format timestamp
     - `"range_float"`: Float range (e.g., `1.0..10.0`)
   - `notation` (string): The parsed specification notation
   - `value` (number|string): The final result
-    - For `dice`: Sum of all rolls (number)
+    - For `dice`: Sum of all rolls plus modifier (number, can be negative)
     - For `range_int`: The generated integer (number)
     - For `range_float`: Formatted string with precision
+  - `modifier` (number): The modifier applied to dice rolls (dice only, can be negative)
   - `precision` (number): Decimal places (float ranges only)
   - `source` (array): Raw data
-    - For `dice`: Individual roll results
+    - For `dice`: Individual roll results (before modifier)
     - For `range_float`: Full-precision floating point value(s)
     - Not present for `range_int`
 
 **Examples**:
 
 ```bash
-# Dice roll
+# Dice roll without modifier
 giv --json rng 3d6
 ```
 
@@ -301,7 +302,46 @@ giv --json rng 3d6
       "type": "dice",
       "notation": "3d6",
       "value": 13,
+      "modifier": 0,
       "source": [6, 4, 3]
+    }
+  ]
+}
+```
+
+```bash
+# Dice roll with positive modifier
+giv --json rng 3d6+2
+```
+
+```json
+{
+  "rng": [
+    {
+      "type": "dice",
+      "notation": "3d6+2",
+      "value": 15,
+      "modifier": 2,
+      "source": [5, 6, 2]
+    }
+  ]
+}
+```
+
+```bash
+# Dice roll with negative modifier
+giv --json rng 1d20-1
+```
+
+```json
+{
+  "rng": [
+    {
+      "type": "dice",
+      "notation": "d20-1",
+      "value": 14,
+      "modifier": -1,
+      "source": [15]
     }
   ]
 }
@@ -355,6 +395,7 @@ giv --json rng 2d6 1..100 0.0..1.0
       "type": "dice",
       "notation": "2d6",
       "value": 8,
+      "modifier": 0,
       "source": [5, 3]
     },
     {

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -207,14 +207,76 @@ giv --json now
 
 ---
 
+### `rng` - Random Number Generation
+
+Generate random numbers using dice notation, integer ranges, or float ranges.
+
+**Usage**: `giv rng <SPEC>...`
+
+**Arguments**:
+
+- `SPEC`: One or more specifications for random number generation
+  - Dice notation: `XdY` or `dY` (e.g., `3d6`, `d20`)
+    - Optional modifiers: `+N` or `-N` (e.g., `3d6+2`, `1d20-1`)
+  - Integer ranges: `X..Y` (e.g., `1..100`)
+  - Float ranges: `X.Y..A.B` (e.g., `0.0..1.0`, `1.5..10.75`)
+
+**Examples**:
+
+```bash
+# Roll a single six-sided die
+giv rng d6
+# Output: 4
+
+# Roll three six-sided dice
+giv rng 3d6
+# Output: 11
+
+# Roll dice with positive modifier
+giv rng 3d6+2
+# Output: 15
+
+# Roll dice with negative modifier
+giv rng 1d20-1
+# Output: 14
+
+# Generate integer in range
+giv rng 1..100
+# Output: 42
+
+# Generate float in range
+giv rng 0.0..1.0
+# Output: 0.7
+
+# Multiple specifications
+giv rng 2d6 1d20+5 1..100
+# Output:
+# 8
+# 19
+# 67
+
+# JSON output
+giv --json rng 3d6+2
+# Output: {"rng":[{"type":"dice","notation":"3d6+2","value":15,"modifier":2,"source":[5,6,2]}]}
+```
+
+**Notes**:
+
+- Dice modifiers can result in negative values (e.g., `1d4-10` might return `-6`)
+- Arithmetic operations use overflow checking for safety
+- Float precision is determined by decimal places in the specification
+
+---
+
 ## Feature Compilation
 
 The `giv` tool supports conditional compilation of features. Commands are only available when their corresponding features are enabled:
 
 - `key` command: Requires `key` feature
-- `uuid` command: Requires `uuid` feature  
+- `uuid` command: Requires `uuid` feature
 - `pi` command: Requires `pi` feature
 - `date` and `now` commands: Require `date` feature
+- `rng` command: Requires `rng` feature
 - `--json` flag: Requires `json` feature
 
 ## Help and Version

--- a/src/c_rng/result.rs
+++ b/src/c_rng/result.rs
@@ -9,8 +9,10 @@ pub enum RngResult {
     Dice {
         /// The dice notation used
         notation: String,
-        /// The sum of all rolls
-        value: u64,
+        /// The sum of all rolls plus modifier
+        value: i64,
+        /// The modifier applied (can be negative)
+        modifier: i64,
         /// The individual roll results
         source: Vec<u64>,
     },

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,11 @@ pub enum GivError {
     #[error("Invalid RNG specification: '{0}'. Expected formats: 'XdY' or 'dY' for dice, 'X..Y' for ranges")]
     InvalidRngSpec(String),
 
+    /// Error when a numeric overflow or underflow occurs.
+    #[cfg(feature = "rng")]
+    #[error("Numeric overflow or underflow in calculation: {0}")]
+    NumericOverflow(String),
+
     /// Error when required arguments are not provided.
     #[error("Required arguments not provided. Use '{0}' for usage information")]
     RequiredArgumentsNotProvided(String),


### PR DESCRIPTION
## Summary

Implements dice modifiers (+/-N) for the RNG command to complete the core functionality requested in #1.

## Changes

### Features
- **Dice modifiers**: Support `+N` and `-N` syntax (e.g., `3d6+2`, `1d20-1`)
- **Negative results**: Can produce negative values (e.g., `1d4-10` → `-6`)
- **Overflow protection**: All arithmetic uses checked operations (`checked_add`, `try_from`)

### Implementation Details
- Added `NumericOverflow` error variant for arithmetic failures
- Updated `RngSpec::Dice` to include `modifier: i64` field
- Parser recognizes `+N`/`-N` suffix after dice notation
- Changed dice result `value` from `u64` → `i64` to support negative results
- Added `modifier` field to dice JSON output
- Notation formatting includes modifier (e.g., `"3d6+2"`, `"d20-1"`)

### Documentation
- Added comprehensive RNG command section to `docs/Usage.md`
- Updated `docs/JSON.md` with modifier field examples
- Included overflow protection notes

## Examples

```bash
# Positive modifier
giv rng 3d6+2
# Output: 15

# Negative modifier
giv rng 1d20-1
# Output: 14

# Can produce negative results
giv rng 1d4-10
# Output: -6

# JSON output includes modifier
giv --json rng 3d6+2
# Output: {"rng":[{"type":"dice","notation":"3d6+2","value":15,"modifier":2,"source":[5,6,2]}]}
```

## Testing

- ✅ All tests pass (17/17)
- ✅ Clippy passes (no warnings)
- ✅ Manual testing verified
- Added tests for modifiers and overflow cases

## Issue Progress

Closes the dice modifier portion of #1. The remaining features (negative ranges, multiplier syntax) were evaluated and decided against for scope/complexity reasons.

**Changes**: +286 -19 lines