### PR TITLE
Add repository, crates.io, and docs.rs links to --version output

### DIFF
--- a/src/app/cli/args.rs
+++ b/src/app/cli/args.rs
@@ -1,9 +1,41 @@
 use super::Commands;
 use clap::Parser;
 
+/// Build the long version string with repository and package links.
+///
+/// # Panics
+///
+/// Panics if CARGO_PKG_VERSION, CARGO_PKG_REPOSITORY, or CARGO_PKG_NAME environment variables are not set at compile time.
+const fn long_version() -> &'static str {
+    concat!(
+        // The version.
+        env!("CARGO_PKG_VERSION"),
+        "\n\n",
+        // The Git Repository.
+        "Repository:    ",
+        env!("CARGO_PKG_REPOSITORY"),
+        "/tree/v",
+        env!("CARGO_PKG_VERSION"),
+        "\n",
+        // The crates.io link.
+        "Crate:         ",
+        "https://crates.io/crates/",
+        env!("CARGO_PKG_NAME"),
+        "/",
+        env!("CARGO_PKG_VERSION"),
+        "\n",
+        // The docs.rs link.
+        "Documentation: ",
+        "https://docs.rs/",
+        env!("CARGO_PKG_NAME"),
+        "/",
+        env!("CARGO_PKG_VERSION")
+    )
+}
+
 /// A command-line utility generating values.
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None, long_version = long_version())]
 pub struct Cli {
     /// Format the output as JSON.
     #[cfg(feature = "json")]


### PR DESCRIPTION
## Summary

- Adds version-specific links to `--version` output for repository, crates.io, and docs.rs
- Makes it easy for users to find documentation and resources for their installed version

## Changes

- Added `long_version()` const function in `src/app/cli/args.rs` that builds an extended version string using compile-time environment variables
- Configured clap to use `long_version` for `--version` output
- All links include version numbers and point to version-specific resources

## Output

```
giv 0.1.0

Repository:    https://github.com/theroyalwhee0/giv/tree/v0.1.0
Crate:         https://crates.io/crates/giv/0.1.0
Documentation: https://docs.rs/giv/0.1.0
```

## Test plan

- [x] Built and tested `--version` output
- [x] All tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy`)
- [x] Links are version-specific and point to correct resources

Resolves #17