### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2025-10-02
+
+### Fixed
+
+- Binary installation now works with `cargo install giv` without requiring `--features="bin"` (#28, #29)
+  - Added `bin` to default features
+  - Removed unused `date()` function from build_info that required chrono dependency
+
 ## [0.2.0] - 2025-10-02
 
 ### Added
@@ -59,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Structured output system with `Output` trait
 - Comprehensive documentation and usage guides
 
-[unreleased]: https://github.com/theroyalwhee0/giv/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/theroyalwhee0/giv/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/theroyalwhee0/giv/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/theroyalwhee0/giv/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/theroyalwhee0/giv/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "giv"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "giv"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "A CLI for generating useful values."
 authors = ["Adam Mill <hismajesty@theroyalwhee.com>"]


### PR DESCRIPTION
## Summary

Release v0.2.1 - a patch release to fix the default features issue.

## Changes

### Fixed

- Binary installation now works with `cargo install giv` without requiring `--features="bin"` (#28, #29)
  - Added `bin` to default features
  - Removed unused `date()` function from build_info that required chrono dependency

## Pre-release Verification

- ✅ CHANGELOG.md updated with v0.2.1 section
- ✅ All tests pass (37 unit + 30 binary + 5 doc tests)
- ✅ Clippy clean (no warnings)
- ✅ Documentation builds successfully
- ✅ Binary installs and runs correctly
- ✅ Version bumped to 0.2.1 using `cargo set-version`

## Post-merge Steps

After this PR is merged to main:
1. Switch to main and pull
2. Create and push git tag: `git tag v0.2.1 && git push origin v0.2.1`
3. Publish to crates.io: `cargo publish`
4. Verify publication: `cargo search giv --limit 1`
5. Create GitHub release from tag with CHANGELOG excerpt
6. Close issue #30

Part of #30