### PR TITLE
Fix: Add LICENSE.txt to .gitignore whitelist (issue #35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 !/REPRODUCIBLE.md
 !/SECURITY.md
 !/CHANGELOG.md
+!/LICENSE.txt
 !docs/**/*.md
 
 # Rust ecosystem.


### PR DESCRIPTION
## Summary
- Add `LICENSE.txt` to the `.gitignore` whitelist to allow it to be tracked in version control

## Test plan
- [x] Verify `.gitignore` change is correct
- [x] Confirm `LICENSE.txt` is now tracked by git
- [x] Run `git status` to verify clean working tree