### PR TITLE
Complete community standards documentation (issue #34)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 !/CHANGELOG.md
 !/LICENSE.txt
 !/CODE_OF_CONDUCT.md
+!/CONTRIBUTING.md
 !docs/**/*.md
 
 # Rust ecosystem.

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 !/SECURITY.md
 !/CHANGELOG.md
 !/LICENSE.txt
+!/CODE_OF_CONDUCT.md
 !docs/**/*.md
 
 # Rust ecosystem.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,90 @@
+
+# Contributor Covenant 3.0 Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, **Please email hismajesty@theroyalwhee.com to report any issues. Please include 'COMMUNITY INCIDENT` in the subject to improve classification of the email.**
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+
+## Addressing and Repairing Harm
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1) Warning
+   1) Event: A violation involving a single incident or series of incidents.
+   2) Consequence: A private, written warning from the Community Moderators.
+   3) Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2) Temporarily Limited Activities
+   1) Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2) Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3) Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3) Temporary Suspension
+   1) Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   2) Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3) Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4) Permanent Ban
+   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2) Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3) Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
+
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,130 @@
+# Contributing to giv
+
+Thank you for your interest in contributing to `giv`! This document provides guidelines for contributing to the project.
+
+## Code of Conduct
+
+This project adheres to the Contributor Covenant [Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
+## How to Contribute
+
+### Reporting Bugs
+
+If you find a bug, please create an issue with:
+
+- A clear, descriptive title
+- Steps to reproduce the problem
+- Expected vs actual behavior
+- Your environment (OS, Rust version, `giv` version)
+- Any relevant error messages or logs
+
+### Suggesting Enhancements
+
+Enhancement suggestions are welcome! Please create an issue describing:
+
+- The motivation for the enhancement
+- A clear description of the proposed functionality
+- Any potential implementation considerations
+
+### Pull Requests
+
+1. **Fork and Clone**: Fork the repository and clone it locally
+2. **Create a Branch**: Create a feature branch from `main`
+3. **Make Changes**: Follow the project's coding standards (see below)
+4. **Test**: Ensure all tests pass with `cargo test`
+5. **Lint**: Run `cargo clippy` and address any warnings
+6. **Commit**: Write clear, descriptive commit messages
+7. **Push**: Push your branch to your fork
+8. **Open a PR**: Submit a pull request to the `main` branch
+
+## Development Setup
+
+```bash
+# Clone your fork
+git clone https://github.com/YOUR-USERNAME/giv.git
+cd giv
+
+# Build the project
+cargo build
+
+# Run tests
+cargo test
+
+# Run clippy
+cargo clippy
+
+# Run the CLI locally
+cargo run --features="bin" -- --help
+```
+
+## Coding Standards
+
+This project maintains strict code quality standards:
+
+### Required Practices
+
+- **No unsafe code**: The codebase forbids `unsafe` code
+- **Comprehensive documentation**: All items (public and private) must be documented
+  - Include `# Errors`, `# Panics`, and `# Safety` sections where applicable
+- **No direct output**: Use the `output` module instead of `println!` or `eprintln!`
+- **One item per file**: Generally, place one public item (struct, enum, or trait) per file
+  - File names should match the item name
+  - Include a comment if violating this guideline
+
+### Code Organization
+
+- **Command modules**: Follow the existing pattern with feature flags
+- **Output types**: Implement the `Output` trait for both plain text and JSON output
+- **Error handling**: Use `Result` types with descriptive `GivError` variants
+- **Testing**: Add tests for new functionality in `#[cfg(test)]` modules
+
+### Whitelist .gitignore
+
+This project uses a whitelist approach to version control. Only explicitly allowed files are tracked. When adding new files:
+
+- Source code: Automatically included if in `src/**/*.rs`
+- Documentation: Update `.gitignore` if adding new docs outside `docs/`
+- Scripts: Update `.gitignore` if adding scripts outside `scripts/`
+
+## Adding a New Command
+
+To add a new command:
+
+1. Create `src/commandname/mod.rs` with the command logic
+2. Create `src/commandname/output.rs` implementing the `Output` trait
+3. Add a feature flag to `Cargo.toml`
+4. Add the command variant to `src/app/cli/commands.rs`
+5. Add the command handler to `src/app/mod.rs`
+6. Gate code with `#[cfg(feature = "commandname")]`
+7. Update documentation (README.md, help text, etc.)
+8. Add tests
+
+## Testing
+
+- Write unit tests for new functionality
+- Test both plain text and JSON output modes
+- Ensure tests pass with `cargo test`
+- Document test panic expectations
+
+## Documentation
+
+- Update README.md for user-facing changes
+- Add rustdoc comments for all public APIs
+- Include examples in documentation where helpful
+- Run `cargo doc --open` to preview documentation
+
+## Dependencies
+
+- Keep dependencies minimal and well-vetted
+- Security is a priority (use cryptographic-strength randomness)
+- Discuss new dependencies before adding them
+- Use feature flags to keep dependencies optional when possible
+
+## Questions?
+
+If you have questions about contributing, feel free to:
+
+- Open an issue for discussion
+- Check existing issues and pull requests for context
+
+Thank you for contributing to `giv`!


### PR DESCRIPTION
## Summary
- Add CODE_OF_CONDUCT.md (Contributor Covenant 3.0)
- Add CONTRIBUTING.md with comprehensive contribution guidelines
- Update .gitignore to whitelist both new documentation files

## Test plan
- [x] Verify CODE_OF_CONDUCT.md is properly formatted
- [x] Verify CONTRIBUTING.md covers all necessary guidelines
- [x] Confirm files are tracked by git
- [ ] Check GitHub community standards page after merge