### PR TITLE
Apply template improvements to project (issue #40)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 !*/
 !*/**/
 
+# Configuration.
+!.markdownlintrc
+
 # Documentation.
 !README.md
 !/REPRODUCIBLE.md
@@ -12,6 +15,7 @@
 !/LICENSE.txt
 !/CODE_OF_CONDUCT.md
 !/CONTRIBUTING.md
+!/CLAUDE.md
 !docs/**/*.md
 
 # Rust ecosystem.

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,0 +1,6 @@
+{
+  "MD013": false,
+  "MD024": {
+    "siblings_only": true
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,267 @@
+# giv - Project Context for Claude
+
+## Project Overview
+
+`giv` is a Rust CLI tool and library for generating useful values (dates, UUIDs, keys, pi digits, random numbers, bytes, emoji, and special characters). Published on crates.io, it emphasizes strict code quality, comprehensive documentation, and safe coding practices.
+
+The project provides both:
+
+- **Binary**: A command-line tool (`giv`) for interactive use
+- **Library**: Rust API for programmatic access to all generation functions
+
+## Key Project Characteristics
+
+### Strict Linting and Quality Standards
+
+- **Forbidden unsafe code**: `unsafe_code = "forbid"`
+- **Required documentation**: All items (public and private) must be documented
+  - Missing docs are denied (both code and rustdoc)
+  - All functions must include `# Errors`, `# Panics`, and `# Safety` docs where applicable
+- **No direct stdout/stderr**: Use the `output` module instead
+  - `print_stdout` and `print_stderr` are denied in clippy
+  - All output goes through the structured output system
+
+### Architecture Patterns
+
+- **Command modules**: Named with `c_` prefix (e.g., `date`, `key`, `uuid`, `pi`, `rng`, `bytes`, `chars`)
+- **Feature flags**: Each command is a Cargo feature that can be independently enabled/disabled
+- **Output system**:
+  - Core output trait in `app/output/output_trait.rs`
+  - Each command has its own `output.rs` with a structured output type
+  - Supports both plain text and JSON output via the `Output` trait
+  - JSON output uses descriptive object properties (e.g., `{"key":"..."}`, `{"pi":"...","rounded":true}`)
+  - Includes metadata fields where relevant (version, precision, rounding flags, source values)
+- **Error handling**: Custom error types in `error.rs` using `thiserror`
+
+### File Organization (One Item Per File)
+
+- **Guideline**: Place one public item (struct, enum, or trait) per file as a general rule.
+  - File names should match the item name (e.g., `Schema` struct goes in `schema.rs`)
+  - Each file contains the item and all its implementations (Display, Default, methods, etc.)
+  - Type aliases are exempt from this rule and can be grouped logically
+  - When violating this guideline, include a comment explaining why:
+
+    ```rust
+    // Multiple error types grouped together for cohesion.
+    pub enum AtsError { ... }
+    pub enum LexError { ... }
+    ```
+
+- **Benefits of this pattern**:
+  - Clear file-to-type mapping for navigation
+  - Focused context when editing specific types
+  - Precise git history (changes to `Field` only touch `field.rs`)
+  - Reduced merge conflicts when working on different types
+  - Tests can be colocated with their specific type
+
+### Module Organization (mod.rs as Table of Contents)
+
+`mod.rs` files should **only** contain module declarations and re-exports.
+
+- All implementation code (structs, enums, functions, impls, tests) must be in separate files
+- `mod.rs` serves as the module's table of contents
+- Each public item gets its own file following the "one item per file" convention
+
+**Example**:
+
+```rust
+// config/mod.rs - GOOD: Only declarations and re-exports
+pub mod configuration;
+pub mod site;
+pub mod source;
+
+pub use configuration::Configuration;
+pub use site::SiteConfig;
+pub use source::SourceConfig;
+```
+
+**Benefits**: Clear module index, easier navigation, better git history, consistent with "one item per file".
+
+### Code Structure
+
+```text
+src/
+├── main.rs           # Entry point with command routing
+├── error.rs          # Error types
+├── app/              # Application infrastructure
+│   ├── cli/          # Clap-based CLI definitions
+│   ├── output/       # Output trait and formatting
+│   └── context.rs    # Command execution context
+├── bytes/          # Random byte generation
+│   ├── mod.rs
+│   └── output.rs     # BytesOutput struct
+├── chars/          # Emoji and special character conversion
+│   ├── mod.rs
+│   ├── patterns.rs   # Character pattern conversion
+│   └── output.rs     # CharsOutput struct
+├── date/           # Date/time generation
+│   ├── mod.rs
+│   ├── date_format.rs
+│   ├── date_kind.rs
+│   └── output.rs     # DateOutput struct
+├── key/            # Random key generation
+│   ├── mod.rs
+│   └── output.rs     # KeyOutput struct
+├── pi/             # Pi digit generation
+│   ├── mod.rs
+│   ├── decimals.rs   # Pre-calculated pi digits
+│   └── output.rs     # PiOutput struct
+├── rng/            # Random number generation
+│   ├── mod.rs
+│   ├── spec.rs       # Specification parsing
+│   ├── execute.rs    # Execution logic
+│   ├── generator.rs  # RNG functions
+│   ├── result.rs     # Result types
+│   └── output.rs     # RngOutput struct
+└── uuid/           # UUID v7 generation
+    ├── mod.rs
+    └── output.rs     # UuidOutput struct
+```
+
+### Development Workflow
+
+- Install from crates.io: `cargo install giv`
+- Build/install locally: `cargo install --path .`
+- Run locally (binary requires `bin` feature): `cargo run --features="bin" -- --version`
+- Test: `cargo test`
+- Lint: `cargo clippy`
+- Documentation: `cargo doc --open`
+
+### Library Usage
+
+The project exposes a library API alongside the CLI binary. Users can add `giv` as a dependency in their `Cargo.toml`:
+
+```toml
+[dependencies]
+giv = "0.1"
+```
+
+Each command module provides public functions that return structured output types:
+
+```rust
+use giv::uuid::generate_uuid;
+use giv::key::generate_key;
+use giv::pi::get_pi_digits;
+
+fn main() -> Result<(), giv::GivError> {
+    // Generate a UUID v7
+    let uuid = generate_uuid()?;
+    println!("UUID: {}", uuid.uuid);
+
+    // Generate a random key
+    let key = generate_key(Some(32))?;
+    println!("Key: {}", key.key);
+
+    // Get PI digits
+    let pi = get_pi_digits(Some(10), None)?;
+    println!("PI: {}", pi.pi);
+
+    Ok(())
+}
+```
+
+**Key library patterns:**
+
+- All generation functions return `Result<OutputType, GivError>`
+- Output types implement the `Output` trait for formatting
+- Feature flags control which modules are included (default: all)
+- Constants like `DEFAULT_KEY_SIZE` and `PI_DEFAULT_PLACES` are publicly exported
+
+### Release Process
+
+- Update version in `Cargo.toml` following [semver](https://semver.org/)
+- Update `CHANGELOG.md` with release notes
+- Create git tag: `git tag v0.x.x && git push origin v0.x.x`
+- Publish to crates.io: `cargo publish`
+- Current published version: `0.1.0`
+
+### Git Configuration
+
+**Whitelist .gitignore**: This project uses a whitelist approach to version control. By default, all files are ignored (`*`), and only specific file types and paths are explicitly allowed:
+
+- Documentation: `CHANGELOG.md`, `README.md`, `SECURITY.md`, `docs/**/*.md`
+- Rust files: `Cargo.toml`, `Cargo.lock`, `clippy.toml`, `src/**/*.rs`
+- Scripts: `scripts/*.sh`, `scripts/*.py`
+- Project config: `CLAUDE.md`, `.gitignore`
+- Explicitly disallowed: `/target`, `/.focus`, `.local/`
+
+This ensures only intentional source files are committed, preventing accidental inclusion of build artifacts, local config, or temporary files.
+
+### Task Focus Workflow
+
+The `.focus/` folder provides a temporary workspace for development tasks:
+
+- **Purpose**: Store task-specific notes, experiments, and temporary files
+- **Git Status**: Excluded from version control (in `.gitignore`)
+- **Lifecycle**: Contents cleared when switching to new major tasks
+- **Structure**: Typically includes `Task.md`, `Notes.md`, and temporary test files
+- **Focusing an issue**: Use `focus-issue {issue-number}` command to safely fetch and save an issue to `.focus/`
+  - This command handles the directory creation and file saving automatically
+  - NEVER manually create `.focus/` or write to it - always use `focus-issue` instead
+  - The command is safer and prevents potential errors
+
+This keeps experimental work organized without cluttering the main codebase.
+
+### Important Conventions
+
+1. **Documentation First**: Write docs before implementation
+2. **Module Privacy**: Document all private items too
+3. **Error Propagation**: Use `Result` types with descriptive errors
+4. **Output Abstraction**: Never use `println!` or `eprintln!` directly (except in main.rs error handler)
+5. **Feature Gates**: Use `#[cfg(feature = "...")]` for optional functionality
+6. **Structured Output**: All commands must provide structured JSON output with descriptive properties and metadata
+
+### Output Pattern
+
+Each command follows a consistent output pattern:
+
+1. **Output struct**: Define in `output.rs` with `#[derive(Debug, Serialize)]`
+2. **Implement `Output` trait**:
+   - `to_plain()`: Returns simple string output for CLI users
+   - `to_json()`: Returns structured JSON with descriptive properties
+3. **JSON structure guidelines**:
+   - Use object properties, not bare strings (e.g., `{"pi":"..."}` not `"..."`)
+   - Include relevant metadata (version, precision, rounding flags, source data)
+   - Use consistent naming: `source` for raw/unformatted data, `value` for formatted results
+4. **Backward compatibility**: Plain text output should remain simple and unchanged
+
+Example output structures:
+
+- `{"key":"key_xxx"}` - Simple value
+- `{"pi":"3.14","rounded":true}` - Value with metadata
+- `{"uuid":"xxx","version":"v7"}` - Value with version info
+- `{"rng":[{"value":"2.5","source":[2.51...],...}]}` - Array with formatted and raw data
+
+### Common Tasks
+
+- **Adding a new command**:
+  1. Create `c_commandname/mod.rs` module with command logic
+  2. Create `c_commandname/output.rs` implementing the `Output` trait
+     - Define a struct for the command output (e.g., `CommandOutput`)
+     - Implement `to_plain()` for plain text output
+     - Implement `to_json()` for JSON output with descriptive properties
+     - Include metadata fields where relevant (version, precision, flags, etc.)
+  3. Add feature to `Cargo.toml` with dependencies
+  4. Add command variant to `app/cli/commands.rs`
+  5. Add command handler to `app/mod.rs`
+  6. Gate with `#[cfg(feature = "commandname")]`
+
+- **Output formatting**:
+  - Create a structured output type in `output.rs` that implements the `Output` trait
+  - Use `ctx.output().output(&output)` to send output
+  - JSON output should use descriptive object properties, not bare strings
+  - Include contextual metadata (e.g., `{"uuid":"...","version":"v7"}`)
+  - Keep plain text output simple and backward compatible
+
+### Dependencies Philosophy
+
+- Minimal, well-vetted dependencies
+- Feature-gated to keep binary size down
+- Security-focused (e.g., `rand` for cryptographic randomness)
+
+### Testing Notes
+
+- Use `#[cfg(test)]` modules
+- Document test panics expectations
+- Test both plain and JSON output modes
+- IMPORTANT: Never add dependencies without giving me a chance to review it BEFORE you add them.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -21,7 +21,6 @@ With these considerations in mind, we agree to behave mindfully toward each othe
 6. Committing to **repairing harm** when it occurs.
 7. Behaving in other ways that promote and sustain the **well-being of our community**.
 
-
 ## Restricted Behaviors
 
 We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
@@ -41,15 +40,13 @@ We agree to restrict the following behaviors in our community. Instances, threat
 3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
 4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
 
-
 ## Reporting an Issue
 
 Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
 
-When an incident does occur, it is important to report it promptly. To report a possible violation, **Please email hismajesty@theroyalwhee.com to report any issues. Please include 'COMMUNITY INCIDENT` in the subject to improve classification of the email.**
+When an incident does occur, it is important to report it promptly. To report a possible violation, **Please email <hismajesty@theroyalwhee.com> to report any issues. Please include 'COMMUNITY INCIDENT' in the subject to improve classification of the email.**
 
 Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
-
 
 ## Addressing and Repairing Harm
 
@@ -74,11 +71,9 @@ If an investigation by the Community Moderators finds that this Code of Conduct 
 
 This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
 
-
 ## Scope
 
 This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
-
 
 ## Attribution
 
@@ -86,5 +81,4 @@ This Code of Conduct is adapted from the Contributor Covenant, version 3.0, perm
 
 Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
 
-For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).
-
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla's code of conduct team](https://github.com/mozilla/inclusion).

--- a/build.rs
+++ b/build.rs
@@ -27,12 +27,12 @@ fn main() -> io::Result<()> {
     // Get the output directory from Cargo.
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("Expected OUT_DIR to be set"));
 
-    // Find the build directory (two directories up from OUT_DIR).
-    // OUT_DIR is usually something like 'target/debug/build/package-hash/out'.
-    // We want to go up to 'target/debug/'.
+    // Find the build directory by locating the 'build' component.
+    // OUT_DIR is something like 'target/<profile>/build/<package-hash>/out'.
+    // We want 'target/<profile>/'.
     let build_dir = out_dir
-        .parent()
-        .and_then(|p| p.parent())
+        .ancestors()
+        .find(|p| p.file_name().and_then(|n| n.to_str()) == Some("build"))
         .and_then(|p| p.parent())
         .expect("Could not find build directory");
 

--- a/src/build_info.rs
+++ b/src/build_info.rs
@@ -88,8 +88,7 @@ mod tests {
         let profile = profile();
         assert!(
             profile == "debug" || profile == "release",
-            "Profile should be either 'debug' or 'release', got: {}",
-            profile
+            "Profile should be either 'debug' or 'release', got: {profile}"
         );
     }
 
@@ -105,8 +104,7 @@ mod tests {
         // Should follow semver pattern (basic check)
         assert!(
             ver.contains('.'),
-            "Version should contain at least one dot: {}",
-            ver
+            "Version should contain at least one dot: {ver}"
         );
     }
 
@@ -147,7 +145,7 @@ mod tests {
         assert!(date.contains('-'), "ISO date should contain dashes");
         // Verify it starts with a reasonable year
         let year: u32 = date[0..4].parse().expect("Year should be numeric");
-        assert!(year >= 2020 && year <= 2100, "Year should be reasonable");
+        assert!((2020..=2100).contains(&year), "Year should be reasonable");
     }
 
     /// Test that datetime_iso returns a valid ISO 8601 datetime.


### PR DESCRIPTION
## Summary

This PR applies several improvements identified from reviewing the rust template project. All changes improve code quality, add missing tooling configuration, and enhance documentation consistency.

## Changes

### 1. build.rs - Improved Path Finding
- Replaced hardcoded `parent()` calls with `ancestors().find()` for finding build directory
- More robust against changes in Cargo's directory structure
- Improved comments to clarify the search logic

### 2. .markdownlintrc - Added Configuration
- Created markdown linting configuration file
- Disables line length checks (MD013)
- Allows duplicate headers if in different sections (MD024)

### 3. .gitignore - Missing Whitelist Entries
- Added `!.markdownlintrc` to whitelist the new config file
- Explicitly whitelisted `!/CLAUDE.md` for consistency

### 4. CODE_OF_CONDUCT.md - Fixes
- Fixed typo on line 49: backtick → single quote in 'COMMUNITY INCIDENT'
- Removed multiple consecutive blank lines (MD012 violations)
- Wrapped bare email URL in angle brackets to satisfy MD034
- Added trailing newline (MD047)

### 5. CLAUDE.md - Enhanced Documentation
- Added "Module Organization (mod.rs as Table of Contents)" section from template
- Provides guidance on keeping mod.rs files clean and focused
- Added blank lines around lists for proper markdown formatting (MD032)

### 6. build_info.rs - Clippy Fixes
- Fixed uninlined_format_args warnings
- Fixed manual_range_contains warning
- These were pre-existing issues caught by clippy during commit

## Testing

- ✅ All pre-commit hooks passed
- ✅ Clippy checks passed (including fixes)
- ✅ Markdown lint checks passed
- ✅ All unit and integration tests passed
- ✅ Doc tests passed
- ✅ Code coverage: 123 tests, 1117 lines covered

## Closes

Closes #40