### PR TITLE
Add lorem command documentation to README (issue #49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ A CLI for generating useful values.
   - `giv now`: Prints the current time in various formats.
 - `giv uuid`: Print a random UUID v7.
 - `giv key`: Prints a strong random key with a 'key_' prefix.
+- `giv lorem`: Generate lorem ipsum placeholder text.
+  - Words (default): `giv lorem 50`
+  - Sentences: `giv lorem -s 3`
+  - Paragraphs: `giv lorem -p 2`
 - `giv pi`: Prints the requested number of digits of PI with rounding.
 - `giv rng`: Generate cryptographically secure random numbers.
   - Dice notation: `giv rng 2d6`, `giv rng d20`


### PR DESCRIPTION
## Summary

Adds documentation for the `lorem` command to the README's Available Commands section.

## Changes

Added `giv lorem` documentation between `giv key` and `giv pi` (alphabetically) with examples:
- Words mode (default): `giv lorem 50`
- Sentences mode: `giv lorem -s 3`
- Paragraphs mode: `giv lorem -p 2`

## Test Plan

- [x] Pre-commit hooks pass
- [x] README renders correctly
- [x] Examples are accurate

Closes #49