### PR TITLE
Fix paragraph formatting consistency (issue #51)

### DIFF
--- a/src/lorem/mod.rs
+++ b/src/lorem/mod.rs
@@ -260,7 +260,11 @@ fn generate_lorem_text(count: usize, unit: LoremUnit) -> Result<String, GivError
                 .map(|(i, _)| {
                     if i == 0 {
                         // First paragraph is the complete classic lorem ipsum
-                        lipsum::LOREM_IPSUM.trim().to_string()
+                        // Remove internal newlines to match other paragraphs
+                        lipsum::LOREM_IPSUM
+                            .split_whitespace()
+                            .collect::<Vec<_>>()
+                            .join(" ")
                     } else {
                         // Subsequent paragraphs are random
                         get_some_sentences(SENTENCES_PER_PARAGRAPH_RANGE, false)
@@ -380,14 +384,17 @@ mod tests {
     /// Test that paragraphs mode starts with full classic lorem ipsum.
     #[test]
     fn test_paragraphs_classic_opening() {
-        // First paragraph should be the full classic lorem ipsum
+        // First paragraph should be the full classic lorem ipsum (without internal newlines)
         let text = generate_lorem_text(1, LoremUnit::Paragraphs).unwrap();
-        let classic = lipsum::LOREM_IPSUM.trim();
+        let classic = lipsum::LOREM_IPSUM
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
         assert_eq!(text, classic);
 
         // Multiple paragraphs - first should be classic, followed by double newline
         let text = generate_lorem_text(2, LoremUnit::Paragraphs).unwrap();
-        assert!(text.starts_with(classic));
+        assert!(text.starts_with(&classic));
         assert!(text.contains("\n\n"));
     }
 


### PR DESCRIPTION
## Summary

Fixes #51 - Removes internal newlines from the first lorem ipsum paragraph to ensure consistent formatting across all paragraphs.

## Changes

- Modified `src/lorem/mod.rs` to remove internal line breaks from the classic Lorem ipsum paragraph
- Updated test to verify the new format
- All paragraphs now render as single lines separated by double newlines

## Test plan

- [x] All existing tests pass (9/9 lorem tests)
- [x] Code coverage maintained at 96.24%
- [x] Manual verification with `giv lorem -p 2` shows consistent formatting